### PR TITLE
クレジットカードの数値数制限

### DIFF
--- a/app/assets/stylesheets/payments/payments.scss
+++ b/app/assets/stylesheets/payments/payments.scss
@@ -23,6 +23,7 @@
 
 .card-png{
   width: 20vw;
+  margin-top: 0.3vh;
 }
 
 .card-indo{

--- a/app/views/payments/new.html.haml
+++ b/app/views/payments/new.html.haml
@@ -35,7 +35,7 @@
             .form-group
               %span.registration_font カード番号
               %span.require-icon 必須
-              = form.text_field :card_number, placeholder: "半角英数のみ", class:"input-default"
+              = form.text_field :card_number, :maxlength => "16", placeholder: "半角、ハイフン（ー）は除いて16桁入力", class:"input-default"
               = image_tag "card.png", class:"card-png"
 
             .form-group

--- a/db/migrate/20190302104211_add_card_number_to_payments.rb
+++ b/db/migrate/20190302104211_add_card_number_to_payments.rb
@@ -1,0 +1,5 @@
+class AddCardNumberToPayments < ActiveRecord::Migration[5.1]
+  def change
+    change_column :payments, :card_number, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190301070405) do
+ActiveRecord::Schema.define(version: 20190302104211) do
 
   create_table "payments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer "card_number", null: false
+    t.bigint "card_number", null: false
     t.date "expiration_date", null: false
     t.integer "security_code", null: false
     t.bigint "user_id", null: false


### PR DESCRIPTION
＃WHAT
card_numberカラムのIntegerの方をbigintへ変更しlimit:
4バイト数から８バイトへ変更し数値が１９桁入るようになりました。